### PR TITLE
Add missing rsync tool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           paths = with pkgs; [
             dockerTools.caCertificates
             lsyncd
+            rsync
           ];
           pathsToLink = ["/bin" "/etc" "/var"];
         };
@@ -35,6 +36,7 @@
           paths = with pkgs.pkgsCross.aarch64-multiplatform; [
             dockerTools.caCertificates
             lsyncd
+            rsync
           ];
           pathsToLink = ["/bin" "/etc" "/var"];
         };


### PR DESCRIPTION
lsync depends on rsync however it doesn't 'depend on it'